### PR TITLE
update ocean_bgc tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,11 +30,11 @@
 	path = src/SIS2
 	url = https://github.com/NOAA-GFDL/SIS2.git
 	branch = dev/gfdl
-[submodule "src/ocean_BGC"]
-	path = src/ocean_BGC
-	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
-	branch = dev/cefi 
 [submodule "src/MOM6"]
 	path = src/MOM6
 	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6.git
+	branch = dev/cefi
+[submodule "src/ocean_BGC"]
+	path = src/ocean_BGC
+	url = https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC.git
 	branch = dev/cefi


### PR DESCRIPTION
As titled. See comments [here](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC/pull/6#pullrequestreview-1837170488). Performance (timing) seems to be close to the case without the bug fix (at least in the [RT case](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/MOM6_OBGC_examples/actions/runs/7616505305)).